### PR TITLE
feat: ignore integer as extension

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,8 +9,12 @@ const path = require('path');
  * @return  {string}            The new path with the proper extension.
  */
 function changeFileExtension(filename, ext) {
+  const orgFilename = path.parse(filename);
+
   return path.format({
-    ...path.parse(filename),
+    ...orgFilename,
+    // filename can contain periods followed by a integer without using the integer as an extension
+    name: /^\.[0-9]+/.test(orgFilename.ext) ? orgFilename.base : orgFilename.name,
     ext: ext.startsWith('.') ? ext : `.${ext}`,
     base: undefined,
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,6 +12,10 @@ test('changeFileExtension without period', (t) => {
   t.is(changeFileExtension(path, 'new'), out);
 });
 
+test('changeFileExtension with extension being an integer', (t) => {
+  t.is(changeFileExtension('this/file1.1', '.new'), 'this/file1.1.new');
+});
+
 test('testYear not throws for valid year', (t) => {
   t.notThrows(() => testYear(1990));
 });


### PR DESCRIPTION
File name with extension that are only integers will be treated as
filenames without extensions. In other words, they are part of the name.
i.e. file1.1 will be file1.1.json and NOT file1.json