### PR TITLE
fix: check if no results before anything else

### DIFF
--- a/src/cli-search.js
+++ b/src/cli-search.js
@@ -128,7 +128,7 @@ async function search() {
       console.error(`Error writing JSON file:\n${error}`);
       process.exit(6);
     }
-    if (argv.excel) json2xls(results.articles, changeFileExtension(argv.output, '.xls'));
+    if (argv.excel) await json2xls(results.articles, changeFileExtension(argv.output, '.xls'));
   }
 }
 search();

--- a/src/lib/json2xls.js
+++ b/src/lib/json2xls.js
@@ -19,7 +19,7 @@ function authorsString(authors) {
  * @param  {object[]]}  results      The results from scrapping IEEE, each result is an Object inside this array.
  * @param  {string}     xlsFilename  The path and filename where to save the Excel file.
  */
-function fromResults(results, xlsFilename) {
+async function fromResults(results, xlsFilename) {
   const COLUMNS = {
     publication_year: 1,
     article_number: 2,


### PR DESCRIPTION
Instead of waiting for results until timeout, we now first check if there are no results to speed up everything.
This also simplifies the try, catch block.