### PR TITLE
fix: don't add extension to output if it's already the correct one

### DIFF
--- a/src/cli-logic.js
+++ b/src/cli-logic.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const { fromResults } = require('./lib/json2xls');
 const { logicOperations } = require('./lib/logicOperations');
+const { changeFileExtension } = require('./lib/utils');
 
 const { argv } = yargs
   .version(require('../package').version)
@@ -104,13 +105,13 @@ async function logic() {
   const result = logicOperations(argv);
   if (result.length > 0) {
     console.log('Operation returned %s results', result.length);
-    await fs.writeJson(`${argv.output}.json`, result, { spaces: 1 });
-    if (argv.excel) await fromResults(result, `${argv.output}.xls`);
+    await fs.writeJson(changeFileExtension(argv.output, '.json'), result, { spaces: 1 });
+    if (argv.excel) await fromResults(result, changeFileExtension(argv.output, '.xls'));
   } else if (result.length === 0) {
     console.log('Logic operation returned zero results. No files will be saved.');
   }
 }
 
 argv.jsonFile
-  ? fromResults(fs.readJsonSync(argv.jsonFile), `${argv.output}.xls`)
+  ? fromResults(fs.readJsonSync(argv.jsonFile), changeFileExtension(argv.output, '.xls'))
   : logic();

--- a/src/cli-search.js
+++ b/src/cli-search.js
@@ -6,6 +6,7 @@ const { testYear } = require('./lib/utils');
 const { FIELDS, addDataField } = require('./lib/dataFields');
 const ieee = require('./lib/ieeeAPI');
 const { fromResults: json2xls } = require('./lib/json2xls');
+const { changeFileExtension } = require('./lib/utils');
 
 const { APIKEY } = process.env;
 
@@ -122,13 +123,13 @@ async function search() {
   }
   if (results.total_records > 0) {
     try {
-      await fs.ensureFile(`${argv.output}.json`); // create the parent directory if it doesn't exist
-      await fs.writeJson(`${argv.output}.json`, results.articles, { spaces: 1 });
+      await fs.ensureFile(changeFileExtension(argv.output, '.json')); // create the parent directory if it doesn't exist
+      await fs.writeJson(changeFileExtension(argv.output, '.json'), results.articles, { spaces: 1 });
     } catch (error) {
       console.error(`Error writing JSON file:\n${error}`);
       process.exit(6);
     }
-    if (argv.excel) await json2xls(results.articles, `${argv.output}.xls`);
+    if (argv.excel) await json2xls(results.articles, changeFileExtension(argv.output, '.xls'));
   }
 }
 search();

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,23 +1,16 @@
 const path = require('path');
 
 /**
- * Changes the extension of a filename
+ * Checks if filename has a proper extension, otherwise adds it (doesn't change it)
  *
  * @param   {string}  filename  The path to the file.
- * @param   {string}  ext       The extension to use.
+ * @param   {string}  ext       The extension to compare.
  *
  * @return  {string}            The new path with the proper extension.
  */
 function changeFileExtension(filename, ext) {
-  const orgFilename = path.parse(filename);
-
-  return path.format({
-    ...orgFilename,
-    // filename can contain periods followed by a integer without using the integer as an extension
-    name: /^\.[0-9]+/.test(orgFilename.ext) ? orgFilename.base : orgFilename.name,
-    ext: ext.startsWith('.') ? ext : `.${ext}`,
-    base: undefined,
-  });
+  const tmpExt = ext.startsWith('.') ? ext : `.${ext}`;
+  return path.parse(filename).ext === tmpExt ? filename : filename + tmpExt;
 }
 
 /**

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,18 +2,14 @@ const test = require('ava');
 const { changeFileExtension, testYear } = require('../src/lib/utils');
 
 const path = 'this/file.ext';
-const out = 'this/file.new';
-
-test('changeFileExtension with period', (t) => {
-  t.is(changeFileExtension(path, '.new'), out);
-});
+const out = 'this/file.ext.new';
 
 test('changeFileExtension without period', (t) => {
   t.is(changeFileExtension(path, 'new'), out);
 });
 
-test('changeFileExtension with extension being an integer', (t) => {
-  t.is(changeFileExtension('this/file1.1', '.new'), 'this/file1.1.new');
+test('changeFileExtension with same extension', (t) => {
+  t.is(changeFileExtension(path, '.ext'), path);
 });
 
 test('testYear not throws for valid year', (t) => {


### PR DESCRIPTION
Fixes error when provided output 'out.json` was changed to `out.json.json`, now it'll stay as
'out.json'. The same check is done for '.xls' filenames