### PR TITLE
fix: correctly add a data field to multi-word phrases surrounded by double quotes

### DIFF
--- a/src/lib/ieeeAPI.js
+++ b/src/lib/ieeeAPI.js
@@ -20,9 +20,10 @@ async function scrap(querytext, rangeYear, verbose) {
   const NEXT = 'div.ng-SearchResults.row > div.main-section > xpl-paginator > div.pagination-bar.hide-mobile > ul '
     + '> li.next-btn > a';
 
+  if (verbose) console.log('Query: \t%s\n', querytext);
   const query = `(${encodeURI(querytext).replace(/\?/g, '%3F').replace(/\//g, '%2F')})`
               + `&ranges=${rangeYear[0]}_${rangeYear[1]}_Year`;
-  if (verbose) console.log('QUERY:\t%s\n', query);
+  if (verbose) console.log('Encoded Query:\t%s\n', query);
 
   let totalPages = 1; // counter for total number of pages
 
@@ -78,6 +79,7 @@ async function scrap(querytext, rangeYear, verbose) {
 async function api(apiKey, querytext, rangeYear, verbose) {
   const APIURL = 'https://ieeexploreapi.ieee.org/api/v1/search/articles';
 
+  if (verbose) console.log('Query: \t%s\n', querytext);
   if (verbose >= 2) console.log('ApiKey:\t%s', apiKey);
 
   const config = {

--- a/test/dataFields.js
+++ b/test/dataFields.js
@@ -11,7 +11,13 @@ test('addDataField with field', (t) => {
   t.is(addDataField(query, 'F'), 'F:optics AND F:nano');
 });
 
-test('addDataField with field and parenthesis', (t) => {
-  const query = 'optics AND (nano OR network)';
-  t.is(addDataField(query, 'F'), 'F:optics AND (F:nano OR F:network)');
+// Because of the refactoring, this test is not necessary for coverage, but necessary for parentheses checks
+test('addDataField with field and parentheses', (t) => {
+  const query = 'optics AND ((nano OR network) NEAR (gigabyte))';
+  t.is(addDataField(query, 'F'), 'F:optics AND ((F:nano OR F:network) NEAR (F:gigabyte))');
+});
+
+test('addDataField with a multi-word phase', (t) => {
+  const query = 'optics NEAR/15 "nano network gigabyte"';
+  t.is(addDataField(query, 'F'), 'F:optics NEAR/15 F:"nano network gigabyte"');
 });


### PR DESCRIPTION
Some refactoring was done to the way we test for IEEE search operators, and how terms with
parentheses are found.
The search query, before encoding, is also shown as part of debugging