### PR TITLE
feat(search-scrap)!: use local Chrome installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ node_modules/
 build
 
 # TODO files
+SCOPES.md
 TODO
 WORKFLOW
 results
+ACM DL scrapping

--- a/package-lock.json
+++ b/package-lock.json
@@ -569,9 +569,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
       "optional": true
     },
     "@types/normalize-package-data": {
@@ -2477,6 +2477,11 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-promise": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "escalade": {
       "version": "3.1.1",
@@ -4678,6 +4683,16 @@
         }
       }
     },
+    "locate-chrome": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/locate-chrome/-/locate-chrome-0.1.1.tgz",
+      "integrity": "sha1-XyDR1uyOQJJgO8d9sQ/Zlob6614=",
+      "requires": {
+        "es6-promise": "^2.0.0",
+        "queue-async": "^1.0.0",
+        "userhome": "^1.0.0"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -6008,10 +6023,10 @@
         "escape-goat": "^2.0.0"
       }
     },
-    "puppeteer": {
+    "puppeteer-core": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
       "requires": {
         "debug": "^4.1.0",
         "devtools-protocol": "0.0.818844",
@@ -6032,6 +6047,11 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "queue-async": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz",
+      "integrity": "sha1-BYLgHa4lMljPV2/Co125b8qEf28="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -7044,9 +7064,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -7340,6 +7360,11 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "userhome": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
+      "integrity": "sha1-tkkf8S0hpecmcd+czIcX4cZojAs="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7474,9 +7499,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "axios": "^0.21.1",
     "excel4node": "^1.7.2",
     "fs-extra": "^9.0.1",
+    "locate-chrome": "^0.1.1",
     "lodash": "^4.17.20",
-    "puppeteer": "^5.5.0",
+    "puppeteer-core": "^5.5.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/src/lib/ieeeAPI.js
+++ b/src/lib/ieeeAPI.js
@@ -1,6 +1,7 @@
 const axios = require('axios').default;
 const https = require('https');
-const puppeteer = require('puppeteer');
+const locateChrome = require('locate-chrome');
+const puppeteer = require('puppeteer-core');
 const createJSON = require('./createJson');
 
 /**
@@ -24,12 +25,20 @@ async function scrap(queryText, rangeYear, verbose) {
               + `&ranges=${rangeYear[0]}_${rangeYear[1]}_Year`;
   if (verbose) console.log('Encoded Query:\t%s\n', query);
 
-  let totalPages = 1; // counter for total number of pages
+  const browserPath = await locateChrome();
+  if (!browserPath) {
+    console.error('Can\'t find a valid installation of Chrome');
+    process.exit(2);
+  }
 
+  let totalPages = 1; // counter for total number of pages
   let browser;
   let results;
   try {
-    browser = await puppeteer.launch({ headless: true });
+    browser = await puppeteer.launch({
+      executablePath: browserPath,
+      headless: true,
+    });
     const page = await browser.newPage();
     page.setDefaultTimeout(10000); // only wait 10 secs, any longer and it means there's no results
     await page.goto(ieeeUrl + query);


### PR DESCRIPTION
We no longer use the Chrome binary that comes with puppeteer, instead we
use a local Chrome browser.
This also helps when packaging the app for multiple platforms.

BREAKING CHANGE: A local Chrome installation is required for scrapping

Please make sure that a valid installation of Chrome exists