### PR TITLE
test: fix scrapping results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage
 build
 
 # TODO files
+scrapping fields
 SCOPES.md
 TODO
 WORKFLOW

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -12,7 +12,7 @@ const icons = 'div.row.doc-access-tools-container';
 // Elements inside MAIN
 const AUTHORS = `${main} > xpl-authors-name-list > p.author`;
 const TITLE = `${main} > h2 > a`;
-const JOURNAL = `${main} > div.description > a`;
+const PUBLICATION = `${main} > div.description > a`;
 const DESCRIPTION = `${main} > div.description > div.publisher-info-container`;
 
 // Elements inside ICONS
@@ -23,8 +23,8 @@ window.DATA = {
   ELEMENTS,
   AUTHORS,
   TITLE,
-  ICONS: `${icons} > ul`,
-  JOURNAL,
+  ICONS: `${icons} > ul > li`,
+  PUBLICATION,
   DESCRIPTION,
   ABSTRACT,
   ABSTRACT_URL,

--- a/src/lib/createJson.js
+++ b/src/lib/createJson.js
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, no-restricted-globals */
 /* global DATA */
 
 /**
@@ -7,8 +7,6 @@
  * @returns {object[]}  Each IEEE result is an Object, which are part of the returned Array
  */
 function createJSON() {
-  const ieeeUrl = 'https://ieeexplore.ieee.org';
-
   // Translate between webpage and API types
   const contentType = {
     Course: 'Courses',
@@ -26,7 +24,7 @@ function createJSON() {
     ICONS,
     AUTHORS,
     TITLE,
-    JOURNAL,
+    PUBLICATION,
     DESCRIPTION,
     ABSTRACT,
     ABSTRACT_URL,
@@ -37,51 +35,63 @@ function createJSON() {
     let volume;
     let issue;
 
-    // Retrieve elements
-    const authors = item.querySelector(AUTHORS);
-    const title = (item.querySelector(TITLE) || item.querySelector('h2 > span')).innerText;
-    const journal = item.querySelector(JOURNAL);
     // 'description' is the field that contains publication_year, publisher, content_type and/or volume, and issue
     const description = item.querySelector(DESCRIPTION).innerText.split('|').map((el) => el.trim());
-    const abstract = item.querySelector(ABSTRACT);
-    const abstract_url = item.querySelector(ABSTRACT_URL);
-
     const publication_year = parseInt(description.shift().slice(6), 10);
     const publisher = description.pop().slice(11);
     const type = description.length === 1 ? description.shift() : description.pop();
-    const content_type = contentType[type];
     if (description.length === 1) [volume, issue] = description.shift().split(',').map((el) => el.trim());
 
-    /* ICONS related fields */
+    // Retrieve elements
+    const title = (item.querySelector(TITLE) || item.querySelector('h2 > span')).innerText;
+    const authors = item.querySelector(AUTHORS);
+    const abstract = item.querySelector(ABSTRACT);
+    const abstract_url = item.querySelector(ABSTRACT_URL);
+    const publication = item.querySelector(PUBLICATION);
+
+    // Books and Courses titles are their own publication_title
+    const publication_title = publication ? publication.innerText : title;
+
+    // Books publication number is in the title
+    const publication_number = publication
+      ? publication.getAttribute('href').match(/\d+/).shift()
+      : item.querySelector(TITLE).getAttribute('href').split('/').filter(Boolean)
+        .pop(); // For Books only
+
+    // URLs
     let html_url;
     let pdf_url;
-    let course_url;
-    // First icon is Abstract (whithout the actual content)
-    if (['Journals', 'Conferences', 'Magazines'].includes(content_type)) {
-      html_url = item.querySelector(`${ICONS} > li:nth-child(2) a`);
-      pdf_url = item.querySelector(`${ICONS} > li:nth-child(3) a`);
-    }
-    if (['Books', 'Standards'].includes(content_type)) {
-      pdf_url = item.querySelector(`${ICONS} > li:nth-child(2) a`);
-    }
-    if (content_type === 'Courses') {
-      course_url = item.querySelector(`${ICONS} > li:nth-child(2) a`);
-    }
+    item.querySelectorAll(ICONS).forEach((element) => {
+      const course = element.querySelector('a[title="Access Course"]');
+      const pdf = element.querySelector('xpl-view-pdf');
+      if (pdf) pdf_url = pdf.querySelector('a').href;
+      if (course) html_url = course.href;
+      if (element.innerText === 'HTML') html_url = element.querySelector('a').href;
+    });
+    if (!html_url && abstract_url) html_url = abstract_url.href; // Some results don't have clickable titles
+
+    // article_number get it from title. If title is not a link, get it from PDF.
+    const article_number = item.querySelector(TITLE)
+      ? item.querySelector(TITLE).getAttribute('href').split('/').filter(Boolean)
+        .pop()
+      : (new URL(pdf_url)).searchParams.get('arnumber');
 
     // The result object will all the must have fields
     const result = {
+      article_number,
       title,
       publication_year,
       publisher,
-      content_type,
+      content_type: contentType[type],
+      publication_title,
       authors: {
         authors: authors
           ? Array.from(authors.querySelectorAll('a')).map((value, index) => {
             const author = { full_name: value.innerText, author_order: index + 1 };
-            const url = value.getAttribute('href');
+            const url = value.href;
             if (url) {
-              author.authorUrl = ieeeUrl + url;
-              author.id = parseInt(url.split('/').pop(), 10);
+              author.authorUrl = url;
+              author.id = parseInt(url.split('/').filter(Boolean).pop(), 10);
             }
             return author;
           })
@@ -91,30 +101,12 @@ function createJSON() {
 
     // Optional fields of result object, except for article_number which is a must
     if (abstract) result.abstract = abstract.innerText;
-    if (item.querySelector(TITLE)) {
-      result.article_number = item.querySelector(TITLE).getAttribute('href').split('/').filter(Boolean)
-        .pop();
-    } else {
-      if (course_url) result.article_number = course_url.getAttribute('href').split('/').pop();
-      if (pdf_url) result.article_number = pdf_url.getAttribute('href').match(/\d+/).shift();
-    }
-    //
-    if (abstract_url) result.abstract_url = ieeeUrl + abstract_url.getAttribute('href');
-    if (html_url) result.html_url = ieeeUrl + html_url.getAttribute('href');
+    if (abstract_url) result.abstract_url = abstract_url.href;
+    if (!isNaN(publication_number)) result.publication_number = parseInt(publication_number, 10);
+    if (html_url) result.html_url = html_url;
+    if (pdf_url) result.pdf_url = pdf_url;
     if (volume) result.volume = volume.slice(8);
     if (issue) result.issue = issue.slice(7);
-    if (journal) {
-      result.publication_title = journal.innerText;
-      result.publication_number = parseInt(journal.getAttribute('href').match(/\d+/).shift(), 10);
-    }
-    if (pdf_url) {
-      result.pdf_url = ieeeUrl + pdf_url.getAttribute('href');
-    }
-    if (type === 'Book') {
-      result.publication_title = title;
-      result.publication_number = parseInt(result.article_number, 10);
-    }
-    if (type === 'Standard') delete result.publication_number;
 
     return result;
   });

--- a/test/fixtures/scrap/book.json
+++ b/test/fixtures/scrap/book.json
@@ -1,9 +1,10 @@
 [
  {
+  "article_number": "9100678",
   "title": "3G CDMA2000 Wireless Engineering",
+  "publication_year": 2004,
   "publisher": "Artech",
-  "isbn": "9781580537582",
-  "rank": 1,
+  "content_type": "Books",
   "authors": {
    "authors": [
     {
@@ -12,32 +13,10 @@
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Books",
-  "abstract": "Breaking down complex technology into easy-to-understand concepts, this hands-on, system-level resource offers expert guidance in designing, optimizing, and managing a CDMA2000 wireless network. The book focuses on the development of practical knowledge that can be readily applied in the field, and also provides the theoretical background needed to effectively engineer a 3G network. Offering a deeper, richer treatment of critical topics than other books in this area, this unique reference concentrates on howù and whyù the technology works in addition to providing descriptions of technology. You learn the key requirements of a 3G network and the relevant CDMA2000 features that satisfy these requirements. The book thoroughly explains the protocol layer framework and provides an in-depth discussion of power control and handoff functionalities. Additionally, it delivers an extensive treatment of system performance and design, addressing the important tradeoff between system coverage and capacity. A chapter on network architecture clearly explains how the CDMA2000 interface works and interacts with other elements in the network as a whole. Moreover, the book includes a detailed presentation of 1xEV-DO, explaining the differences between 1xEV-DO and CDMA2000, the ways both technologies operate in tandem, and how 1xEV-DO delivers high-rate packet data services.",
-  "article_number": "9100678",
-  "pdf_url": "https://ieeexplore.ieee.org/xpl/ebooks/bookPdfWithBanner.jsp?fileName=9100679.pdf&bkn=9100678&pdfType=book",
-  "html_url": "https://ieeexplore.ieee.org/document/9100678/",
-  "abstract_url": "https://ieeexplore.ieee.org/document/9100678/",
   "publication_title": "3G CDMA2000 Wireless Engineering",
+  "abstract_url": "https://ieeexplore.ieee.org/document/9100678/",
   "publication_number": 9100678,
-  "publication_year": 2004,
-  "citing_paper_count": 0,
-  "citing_patent_count": 0,
-  "index_terms": {},
-  "isbn_formats": {
-   "isbns": [
-    {
-     "format": "Electronic ISBN",
-     "value": "9781580537582",
-     "isbnType": "New-2005"
-    },
-    {
-     "format": "Electronic ISBN",
-     "value": "1580537588",
-     "isbnType": "Historical"
-    }
-   ]
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/9100678/",
+  "pdf_url": "https://ieeexplore.ieee.org/xpl/ebooks/bookPdfWithBanner.jsp?fileName=9100679.pdf&bkn=9100678&pdfType=book"
  }
 ]

--- a/test/fixtures/scrap/bookChapter.json
+++ b/test/fixtures/scrap/bookChapter.json
@@ -1,23 +1,22 @@
 [
  {
+  "article_number": "6278817",
   "title": "An Evolving and Developing Cellular Electronic Circuit",
+  "publication_year": 2004,
   "publisher": "MIT Press",
-  "isbn": "9780262291392",
-  "rank": 1,
+  "content_type": "Books",
+  "publication_title": "Artificial Life IX: Proceedings of the Ninth International Conference on the Simulation and Synthesis of Living Systems",
   "authors": {
    "authors": [
     {
-     "affiliation": "Brandeis University",
      "full_name": "Jordan Pollack",
      "author_order": 1
     },
     {
-     "affiliation": "Reed College",
      "full_name": "Mark A. Bedau",
      "author_order": 2
     },
     {
-     "affiliation": "University of Sussex",
      "full_name": "Phil Husbands",
      "author_order": 3
     },
@@ -26,40 +25,14 @@
      "author_order": 4
     },
     {
-     "affiliation": "University of Tokyo",
      "full_name": "Takashi Ikegami",
      "author_order": 5
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Books",
-  "abstract": "A novel multi-cellular electronic circuit capable of evolution and development is described here. The circuit is composed of identical cells whose shape and location in the system is arbitrary. Cells all contain the complete genetic description of the final system, as in living organisms. Through a mechanism of development, cells connect to each other using a fully distributed hardware routing mechanism and differentiate by expressing a corresponding part of the genetic code thereby taking a specific functionality and connectivity in the system. The configuration of the system is found by using artificial evolution and intrinsic evolution at the schematic level is possible. Applications include the approximation of boolean functions and the evolution of a controller capable of navigating a Khepera robot while avoiding obstacles. The circuit is suited for a custom chip called POEtic, which is a generic platform to implement bio-inspired applications.",
-  "article_number": "6278817",
-  "pdf_url": "https://ieeexplore.ieee.org/xpl/ebooks/bookPdfWithBanner.jsp?fileName=6278817.pdf&bkn=6267522&pdfType=chapter",
-  "html_url": "https://ieeexplore.ieee.org/document/6278817/",
   "abstract_url": "https://ieeexplore.ieee.org/document/6278817/",
-  "publication_title": "Artificial Life IX: Proceedings of the Ninth International Conference on the Simulation and Synthesis of Living Systems",
   "publication_number": 6267522,
-  "publication_year": 2004,
-  "start_page": "33",
-  "end_page": "38",
-  "citing_paper_count": 0,
-  "citing_patent_count": 0,
-  "index_terms": {},
-  "isbn_formats": {
-   "isbns": [
-    {
-     "format": "Electronic ISBN",
-     "value": "9780262291392",
-     "isbnType": "New-2005"
-    },
-    {
-     "format": "Electronic ISBN",
-     "value": "0262291398",
-     "isbnType": "Historical"
-    }
-   ]
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/6278817/",
+  "pdf_url": "https://ieeexplore.ieee.org/xpl/ebooks/bookPdfWithBanner.jsp?fileName=6278817.pdf&bkn=6267522&pdfType=chapter"
  }
 ]

--- a/test/fixtures/scrap/conferencePaper.json
+++ b/test/fixtures/scrap/conferencePaper.json
@@ -1,30 +1,26 @@
 [
  {
-  "doi": "10.1109/ICASSP.2004.1326466",
+  "article_number": "1326466",
   "title": "Robust two-camera tracking using homography",
+  "publication_year": 2004,
   "publisher": "IEEE",
-  "isbn": "0-7803-8484-9",
-  "issn": "1520-6149",
-  "rank": 1,
-  "volume": "3",
+  "content_type": "Conferences",
+  "publication_title": "2004 IEEE International Conference on Acoustics, Speech, and Signal Processing",
   "authors": {
    "authors": [
     {
-     "affiliation": "Dept. of Electr. & Comput. Eng., Maryland Univ., College Park, MD, USA",
      "authorUrl": "https://ieeexplore.ieee.org/author/37272875300",
      "id": 37272875300,
      "full_name": "Zhanfeng Yue",
      "author_order": 1
     },
     {
-     "affiliation": "Dept. of Electr. & Comput. Eng., Maryland Univ., College Park, MD, USA",
      "authorUrl": "https://ieeexplore.ieee.org/author/37276853500",
      "id": 37276853500,
      "full_name": "S.K. Zhou",
      "author_order": 2
     },
     {
-     "affiliation": "Dept. of Electr. & Comput. Eng., Maryland Univ., College Park, MD, USA",
      "authorUrl": "https://ieeexplore.ieee.org/author/37274537000",
      "id": 37274537000,
      "full_name": "R. Chellappa",
@@ -32,48 +28,10 @@
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Conferences",
-  "abstract": "The paper introduces a two view tracking method which uses the homography relation between the two views to handle occlusions. An adaptive appearance-based model is incorporated in a particle filter to realize robust visual tracking. Occlusion is detected using robust statistics. When there is occlusion in one view, the homography from this view to other views is estimated from previous tracking results and used to infer the correct transformation for the occluded view. Experimental results show the robustness of the two view tracker.",
-  "article_number": "1326466",
-  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1326466",
-  "html_url": "https://ieeexplore.ieee.org/document/1326466/",
   "abstract_url": "https://ieeexplore.ieee.org/document/1326466/",
-  "publication_title": "2004 IEEE International Conference on Acoustics, Speech, and Signal Processing",
-  "conference_location": "Montreal, QC, Canada",
-  "conference_dates": "17-21 May 2004",
   "publication_number": 9248,
-  "is_number": 29345,
-  "publication_year": 2004,
-  "publication_date": "17-21 May 2004",
-  "start_page": "iii",
-  "end_page": "1",
-  "citing_paper_count": 9,
-  "citing_patent_count": 0,
-  "index_terms": {
-   "ieee_terms": {
-    "terms": [
-     "Robustness",
-     "Target tracking",
-     "Cameras",
-     "Statistics",
-     "Maximum likelihood detection",
-     "Bayesian methods",
-     "Collaboration",
-     "Government",
-     "Fuses",
-     "Motion estimation"
-    ]
-   }
-  },
-  "isbn_formats": {
-   "isbns": [
-    {
-     "format": "Print ISBN",
-     "value": "0-7803-8484-9",
-     "isbnType": "Historical"
-    }
-   ]
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/1326466/",
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1326466",
+  "volume": "3"
  }
 ]

--- a/test/fixtures/scrap/course.json
+++ b/test/fixtures/scrap/course.json
@@ -1,9 +1,11 @@
 [
  {
+  "article_number": "EDP006",
   "title": "Challenges Near the Limit of CMOS Scaling",
+  "publication_year": 2004,
   "publisher": "IEEE",
-  "isbn": "0-7803-9645-6",
-  "rank": 1,
+  "content_type": "Courses",
+  "publication_title": "Challenges Near the Limit of CMOS Scaling",
   "authors": {
    "authors": [
     {
@@ -12,43 +14,7 @@
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Courses",
-  "abstract": "Beginning with a brief review of CMOS scaling trends from 1 &#194;&#181;m to 0.1 &#194;&#181;m; this tutorial examines the fundamental factors that will ultimately limit CMOS scaling and considers the design issues near the limit of scaling. The fundamental limiting factors are electron thermal energy; tunneling leakage through gate oxide; and 2D electrostatic scale length. Both the standby power and the active power of a processor chip will increase precipitously below the 0.1-m or 100-nm technology generation. To extend CMOS scaling to the shortest channel length possible while still gaining significant performance benefit, an optimized, vertically and laterally nonuniform doping design (superhalo) is presented. It is projected that room-temperature CMOS will be scaled to 20-nm channel length with the superhalo profile. Low-temperature CMOS allows additional design space to further extend CMOS scaling to near 10 nm. ",
-  "article_number": "EDP006",
-  "html_url": "https://ieeexplore.ieee.org/courses/details/EDP006",
   "abstract_url": "https://ieeexplore.ieee.org/courses/details/EDP006",
-  "publication_title": "Challenges Near the Limit of CMOS Scaling",
-  "publication_year": 2004,
-  "publication_date": "12/1/2004",
-  "citing_paper_count": 0,
-  "citing_patent_count": 0,
-  "index_terms": {
-   "ieee_terms": {
-    "terms": [
-     "CMOS technology",
-     "Scalability",
-     "Tutorials",
-     "Thermal energy",
-     "Logic gates",
-     "Tunneling",
-     "Gate leakage",
-     "MOSFET",
-     "Design methodology",
-     "Leakage currents",
-     "FinFETs",
-     "Subthreshold current",
-     "Volume measurement"
-    ]
-   }
-  },
-  "isbn_formats": {
-   "isbns": [
-    {
-     "format": "Electronic ISBN",
-     "value": "0-7803-9645-6"
-    }
-   ]
-  }
+  "html_url": "https://ieeexplore.ieee.org/courses/details/EDP006"
  }
 ]

--- a/test/fixtures/scrap/journalArticle.json
+++ b/test/fixtures/scrap/journalArticle.json
@@ -1,23 +1,20 @@
 [
  {
-  "doi": "10.1109/JCN.2004.6596633",
+  "article_number": "6596633",
   "title": "Characterization of adaptive modulators in fixed wireless ATM networks",
+  "publication_year": 2004,
   "publisher": "KICS",
-  "issue": "2",
-  "issn": "1976-5541",
-  "rank": 1,
-  "volume": "6",
+  "content_type": "Journals",
+  "publication_title": "Journal of Communications and Networks",
   "authors": {
    "authors": [
     {
-     "affiliation": "Microwave and Wireless Communications Research Lab., Electrical Engineering Department, Amirkabir University of Technology (Tehran Polytechnic), Tehran, Iran",
      "authorUrl": "https://ieeexplore.ieee.org/author/37265914700",
      "id": 37265914700,
      "full_name": "Abbas Mohammadi",
      "author_order": 1
     },
     {
-     "affiliation": "Microwave Research Lab., Vcom Inc., Victoria, Canada",
      "authorUrl": "https://ieeexplore.ieee.org/author/37290705300",
      "id": 37290705300,
      "full_name": "Surinder Kumar",
@@ -25,42 +22,11 @@
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Journals",
-  "abstract": "The various challenges to realize a fixed wireless ATM network are discussed and some solutions for these challenges are presented. In this paper, the capacity allocation in wireless ATM, the wireless link impact on ATM traffic, and the optimum utilization of the wireless network resources for a line of sight (LOS) wireless ATM link are studied. An adaptive MQAM modulator is introduced to provide a suitable solution to these issues. The modulator level is adjusted using a unique QoS metric in a wireless network. The metric, termed modified effective bandwidth, takes into account the bandwidth demand, QoS requirements, and outage conditions of the wireless ATM link. A performance study using VBR MPEG-1 video traffic in a fixed wireless channel (Ricean channel) demonstrates the advantages of the proposed system.",
-  "article_number": "6596633",
-  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6596633",
-  "html_url": "https://ieeexplore.ieee.org/document/6596633/",
   "abstract_url": "https://ieeexplore.ieee.org/document/6596633/",
-  "publication_title": "Journal of Communications and Networks",
   "publication_number": 5449605,
-  "is_number": 6596630,
-  "publication_year": 2004,
-  "publication_date": "June 2004",
-  "start_page": "123",
-  "end_page": "132",
-  "citing_paper_count": 13,
-  "citing_patent_count": 0,
-  "index_terms": {
-   "ieee_terms": {
-    "terms": [
-     "Bandwidth",
-     "Wireless communication",
-     "Modulation",
-     "Streaming media",
-     "Quality of service",
-     "Fading",
-     "Measurement"
-    ]
-   },
-   "author_terms": {
-    "terms": [
-     "Adaptive modulator",
-     "ATM networks",
-     "fixed wireless",
-     "MQAM"
-    ]
-   }
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/6596633/",
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6596633",
+  "issue": "2",
+  "volume": "6"
  }
 ]

--- a/test/fixtures/scrap/magazineArticle.json
+++ b/test/fixtures/scrap/magazineArticle.json
@@ -1,16 +1,14 @@
 [
  {
-  "doi": "10.1109/MCOM.2004.1316535",
+  "article_number": "1316535",
   "title": "Applying the Web ontology language to management information definitions",
+  "publication_year": 2004,
   "publisher": "IEEE",
-  "issue": "7",
-  "issn": "1558-1896",
-  "rank": 1,
-  "volume": "42",
+  "content_type": "Magazines",
+  "publication_title": "IEEE Communications Magazine",
   "authors": {
    "authors": [
     {
-     "affiliation": "Univ. Autonoma de Madrid, Spain",
      "authorUrl": "https://ieeexplore.ieee.org/author/37272981700",
      "id": 37272981700,
      "full_name": "J.E.L. de Vergara",
@@ -30,37 +28,11 @@
     }
    ]
   },
-  "access_type": "LOCKED",
-  "content_type": "Magazines",
-  "abstract": "The extended markup language (XML) has emerged in the Internet world as a standard representation format, which can be useful to describe and transmit management information. However, XML formats alone do not give formal semantics to it. To solve this question, ontology languages based on the resource description framework can be used to improve the expressiveness of management information specifications. This article presents an approach that uses an XML-based ontology language to define network and system management information. For this, the structures of the Web ontology language known as OWL are analyzed and compared to those used in management definitions, also studying the advantages ontology languages can provide in this area.",
-  "article_number": "1316535",
-  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1316535",
-  "html_url": "https://ieeexplore.ieee.org/document/1316535/",
   "abstract_url": "https://ieeexplore.ieee.org/document/1316535/",
-  "publication_title": "IEEE Communications Magazine",
   "publication_number": 35,
-  "is_number": 29172,
-  "publication_year": 2004,
-  "publication_date": "July 2004",
-  "start_page": "68",
-  "end_page": "74",
-  "citing_paper_count": 62,
-  "citing_patent_count": 1,
-  "index_terms": {
-   "ieee_terms": {
-    "terms": [
-     "OWL",
-     "Information management",
-     "Ontologies",
-     "XML",
-     "Resource description framework",
-     "Knowledge management",
-     "Markup languages",
-     "Internet",
-     "Aging",
-     "Engineering management"
-    ]
-   }
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/1316535/",
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1316535",
+  "volume": "42",
+  "issue": "7"
  }
 ]

--- a/test/fixtures/scrap/standard.json
+++ b/test/fixtures/scrap/standard.json
@@ -1,58 +1,16 @@
 [
  {
-  "doi": "10.1109/IEEESTD.2004.94441",
+  "article_number": "1278833",
   "title": "IEEE Guide to the Installation of Overhead Transmission Line Conductors",
+  "publication_year": 2004,
   "publisher": "IEEE",
-  "isbn": "978-0-7381-3815-2",
-  "partnum": "STDSU95170",
-  "rank": 1,
+  "content_type": "Standards",
+  "publication_title": "IEEE Std 524-2003 (Revision of IEEE Std 524-1992)",
   "authors": {
    "authors": []
   },
-  "access_type": "LOCKED",
-  "content_type": "Standards",
-  "abstract": "Revision of IEEE Std 524-1992. SUMMARY: This guide provides general recommendations for the selection of methods, equipment, and tools that have been found to be practical for the stringing of overhead transmission line conductors and overhead groundwires. The guide also includes a comprehensive list of definitions for equipment and tools used in stringing and for stringing terms commonly employed. This guide does not address special conductors such as those used for river and canyon crossing. These conductors may be custom designed and often may require special considerations.",
-  "article_number": "1278833",
-  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1278833",
-  "html_url": "https://ieeexplore.ieee.org/document/1278833/",
   "abstract_url": "https://ieeexplore.ieee.org/document/1278833/",
-  "publication_title": "IEEE Std 524-2003 (Revision of IEEE Std 524-1992)",
-  "standard_number": "524-2003",
-  "standard_status": "Superseded",
-  "publication_number": 9007,
-  "is_number": 28594,
-  "publication_year": 2004,
-  "publication_date": "11 March 2004",
-  "start_page": "1",
-  "end_page": "152",
-  "citing_paper_count": 1,
-  "citing_patent_count": 2,
-  "index_terms": {
-   "ieee_terms": {
-    "terms": [
-     "IEEE Standards",
-     "Conductors",
-     "Power transmission lines",
-     "Patents",
-     "Power engineering",
-     "Tools"
-    ]
-   },
-   "author_terms": {
-    "terms": [
-     "overhead transmission line conductors",
-     "overhead groundwires"
-    ]
-   }
-  },
-  "isbn_formats": {
-   "isbns": [
-    {
-     "format": "Electronic ISBN",
-     "value": "978-0-7381-3815-2",
-     "isbnType": "New-2005"
-    }
-   ]
-  }
+  "html_url": "https://ieeexplore.ieee.org/document/1278833/",
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1278833"
  }
 ]

--- a/test/fixtures/scrap/untitled.json
+++ b/test/fixtures/scrap/untitled.json
@@ -1,0 +1,43 @@
+[
+ {
+  "article_number": "901313",
+  "title": "Nano-optics of quantum dots embedded in pyramidal optical nanostructures",
+  "publication_year": 2000,
+  "publisher": "IEEE",
+  "content_type": "Conferences",
+  "publication_title": "Quantum Electronics and Laser Science Conference (QELS 2000). Technical Digest. Postconference Edition. TOPS Vol.40 (IEEE Cat. No.00CH37089)",
+  "authors": {
+    "authors": [
+      {
+        "full_name": "A. Rahmani",
+        "author_order": 1,
+        "authorUrl": "https://ieeexplore.ieee.org/author/38604543300",
+        "id": 38604543300
+      },
+      {
+        "full_name": "G.W. Bryant",
+        "author_order": 2,
+        "authorUrl": "https://ieeexplore.ieee.org/author/37337828200",
+        "id": 37337828200
+      }
+    ]
+  },
+  "abstract_url": "https://ieeexplore.ieee.org/document/901313/",
+  "publication_number": 7128,
+  "html_url": "https://ieeexplore.ieee.org/document/901313/",
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=901313"
+ },
+ {
+  "article_number": "901279",
+  "title": "Quantum Electronics and Laser Science Conference (QELS 2000). Technical Digest. Postconference Edition. TOPS Vol.40 (IEEE Cat. No.00CH37089)",
+  "publication_year": 2000,
+  "publisher": "IEEE",
+  "content_type": "Conferences",
+  "publication_title": "Quantum Electronics and Laser Science Conference (QELS 2000). Technical Digest. Postconference Edition. TOPS Vol.40 (IEEE Cat. No.00CH37089)",
+  "authors": {
+   "authors": []
+  },
+  "publication_number": 7128,
+  "pdf_url": "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=901279"
+ }
+]

--- a/test/ieeeAPI.test.js
+++ b/test/ieeeAPI.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax, guard-for-in, global-require */
 const { scrap } = require('../src/lib/ieeeAPI');
+const untitled = require('./fixtures/scrap/untitled.json');
 
 const expectedJson = {
   book: require('./fixtures/scrap/book.json'),
@@ -54,8 +55,17 @@ describe.each(testArray)(
     testIf()(label, async () => {
       const result = (await scrap(query, rangeYear, false)).articles[0];
       delete result.abstract;
-      expect(expected).toMatchObject(result);
+      expect(result).toMatchObject(expected);
     });
   },
   20000,
 );
+
+describe('Scrapping', () => {
+  testIf()('Title without link', async () => {
+    const result = (await scrap('optics AND nano AND QELS', [2000, 2000], false)).articles[1];
+    delete result.abstract;
+    expect(result).toMatchObject(untitled[1]);
+  },
+  20000);
+});


### PR DESCRIPTION
Remove all unused keys from expected test fixtures objects, to properly compare to return results.
The code has been refactored to better scrap some keys of results