### PR TITLE
chore(deps): fix vulnerability on jszip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6275,9 +6275,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
-      "integrity": "sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.0.tgz",
+      "integrity": "sha512-Vb3SMfASUN1EKrFzv5A5+lTaZnzLzT5E6A9zyT7WFqMSfhT2Z7iS5FgSOjx2Olm3MDj8OqKj6GHyP2kMt1Ir6w==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -12557,7 +12557,7 @@
       "requires": {
         "deepmerge": "3.2.0",
         "image-size": "0.7.2",
-        "jszip": "3.2.1",
+        "jszip": "^3.9.0",
         "lodash.get": "4.4.2",
         "lodash.isequal": "4.5.0",
         "lodash.isundefined": "3.0.1",
@@ -14225,9 +14225,9 @@
       }
     },
     "jszip": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
-      "integrity": "sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.0.tgz",
+      "integrity": "sha512-Vb3SMfASUN1EKrFzv5A5+lTaZnzLzT5E6A9zyT7WFqMSfhT2Z7iS5FgSOjx2Olm3MDj8OqKj6GHyP2kMt1Ir6w==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "jest": "^27.5.1",
     "pkg": "^5.5.2",
     "standard-version": "^9.3.2"
+  },
+  "overrides": {
+    "jszip": "^3.9.0"
   }
 }


### PR DESCRIPTION
excel4node seem unmaintained and needed an explicit override to update its dependencies.