### PR TITLE
feat(excel)!: use the direct pdf URL for Sci-Hub

### DIFF
--- a/src/lib/json2xls.js
+++ b/src/lib/json2xls.js
@@ -37,7 +37,7 @@ async function fromResults(results, xlsFilename) {
     sciHubBaseUrl: 11,
   };
 
-  const sciHubUrl = 'https://sci-hub.ee/';
+  const sciHubUrl = 'https://sci.bban.top/pdf/';
 
   const wb = new xl.Workbook({
     defaultFont: {
@@ -120,7 +120,7 @@ async function fromResults(results, xlsFilename) {
     ws.cell(i + 2, COLUMNS.pdf_url).link(result.pdf_url || result.abstract_url || '').style(linkStyle);
     if (result.doi) {
       doiHide = false;
-      ws.cell(i + 2, COLUMNS.sci_hub).formula(`HYPERLINK(CONCATENATE($K$1,"${result.doi}"))`).style(linkStyle);
+      ws.cell(i + 2, COLUMNS.sci_hub).formula(`HYPERLINK(CONCATENATE($K$1,"${result.doi}",".pdf"))`).style(linkStyle);
     }
     ws.cell(i + 2, COLUMNS.content_type).string(result.content_type).style(noWrapStyle);
   });


### PR DESCRIPTION
The new URL will help get the PDF directly without having to see the website's sidebar

BREAKING CHANGE: The Excel Sci-Hub URL column will point directly to the PDF and not the website