### PR TITLE
test: make sure test timeouts after scrapping timeouts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 const config = {
-  testTimeout: 20000,
+  testTimeout: 25000,
   verbose: true,
   collectCoverage: true,
   coverageReporters: ['text', 'text-summary'],


### PR DESCRIPTION
By timing out test before Puppeteer can produce a timeout error, we were in the dark as to why tests would fail.
We are allowing Puppeteer to timeout, so those error are propagated to the test suit