### PR TITLE
fix: error messaging for tests

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -48,18 +48,32 @@ function testYear(year) {
 }
 
 /**
- * Escapes a string to be used for regex
+ * Escapes a string to be used for regex.
  *
  * @param    {string}  string  The string to escape.
- * @returns  {string}          The escaped string
+ * @returns  {string}          The escaped string.
  */
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Get line and column numbers of errors without a proper stack.
+ *
+ * @param   {int}  column  The column where the error stack should point to.
+ * @returns {string}    A formatted line ready to be added to an error stack.
+ */
+function getLineStack(column = 0) {
+  let e = new Error();
+  e = e.stack.split('\n')[2].split(/[():]/);
+  e.pop(); e.shift(); // remove unneeded elements
+  return column === 0 ? `    at ${e.join(':')}` : `    at ${e[0]}:${e[1]}:${parseInt(e[2], 10) + column}`;
+}
+
 module.exports = {
   changeFileExtension,
   escapeRegExp,
+  getLineStack,
   testFileExtension,
   testYear,
 };

--- a/test/ieeeAPI.test.js
+++ b/test/ieeeAPI.test.js
@@ -54,7 +54,6 @@ describe.each(testArray)(
   ({ label, query, expected }) => {
     testIf()(label, async () => {
       const results = await scrap(query, rangeYear, false);
-      expect(results.total_records).not.toBe(0);
       const result = results.articles[0];
       delete result.abstract;
       expect(result).toMatchObject(expected);
@@ -67,7 +66,6 @@ describe('Scrapping', () => {
     'Title without link',
     async () => {
       const results = await scrap('optics AND nano AND QELS', [2000, 2000], false);
-      expect(results.total_records).not.toBe(0);
       const result = results.articles[1];
       delete result.abstract;
       expect(result).toMatchObject(untitled[1]);
@@ -80,7 +78,6 @@ describe.each(testArray)(
   ({ label, query, expected }) => {
     testIf()(label, async () => {
       const results = await api(process.env.APIKEY, query, rangeYear, false);
-      expect(results.total_records).not.toBe(0);
       const result = results.articles[0];
       delete result.abstract;
       expect(result).toMatchObject(expected);


### PR DESCRIPTION
Test now have a more meaningful error message.
Users will get the same messages as before, except on API searches.