### PR TITLE
build: better check for tag sections

### DIFF
--- a/bin/dependencies.sh
+++ b/bin/dependencies.sh
@@ -8,7 +8,7 @@ tag=$(git describe --tags --abbrev=0)
 
 # Get dependencies that have changed since last tag
 # If no changes found, it will return a non-zero value
-dependenciesJSON=$(diff --changed-group-format='%>' --unchanged-group-format=''\
+dependenciesJSON=$(/usr/bin/diff --changed-group-format='%>' --unchanged-group-format=''\
  <(git show "${tag}:package.json" | ${gron}) <(${gron} package.json)\
  | grep dependencies\
  | ${gron} --ungron)
@@ -20,8 +20,17 @@ if [[ -n ${dependenciesJSON} ]]; then
 
   # Replace the latest Dependencies section in the Changelog
   line1=$(grep -n -m 1 "### Dependencies" "${changelog}" | cut -d: -f1)
-  line2=$(grep -n -m 2 "### \[" "${changelog}" | tail -1 | cut -d: -f1)
-  line1=$(( line1 + 2 ))
-  line2=$(( line2 - 1 )) # sed already inserts a new line after the last replaceText
-  sed -i "${line1},${line2}c${replaceText//[~^]/}" "${changelog}"
+  line2=$(grep -n -m 2 "## \[" "${changelog}" | tail -1 | cut -d: -f1)
+  line3=$(grep -n -m 2 "### \[" "${changelog}" | tail -1 | cut -d: -f1)
+
+  first_line=$(( line1 + 2 ))
+  # Use the appropriate section to replace. Some section use double or triple hashtags
+  # sed already inserts a new line after the last replaceText, so we remove that line here
+  if [[ ${line2} -le ${line3} ]]; then
+    last_line=$(( line2 - 1 ))
+  else
+    last_line=$(( line3 - 1 ))
+  fi
+
+  sed -i "${first_line},${last_line}c${replaceText//[~^]/}" "${changelog}"
 fi


### PR DESCRIPTION
Major and minor versions use two hashtags, while patch versions use three hashtags. The new code tests for both and uses the latest one.