### PR TITLE
ci: fix errors for bytecode and assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Create executables
       run: |
         TARGET=node${{ env.node-version }}-${{ matrix.platform }}-x64
-        npm run pkg -- -t ${TARGET} src/cli-search.js --output build/ieeeSearch
+        npm run pkg -- -t ${TARGET} src/cli-search.js --output build/ieeeSearch --no-bytecode --public-packages "*" --config .pkg.json
         npm run pkg -- -t ${TARGET} src/cli-logic.js --output build/ieeeLogic
         npm run pkg -- -t ${TARGET} src/cli-count.js --output build/ieeeCount
     - name: Tar files

--- a/.pkg.json
+++ b/.pkg.json
@@ -1,0 +1,5 @@
+{
+  "pkg": {
+    "assets": ["node_modules/axios/**", "node_modules/vm2/**"]
+  }
+}


### PR DESCRIPTION
pkg is having problems with some modules, specially if they use import. The fix is to specifically include them as assets