### PR TITLE
fix: correctly add data fields to search query

### DIFF
--- a/src/lib/dataFields.js
+++ b/src/lib/dataFields.js
@@ -20,26 +20,11 @@ const FIELDS = {
 function addDataField(queryText, field) {
   if (!field) return queryText;
 
-  // test for multiple parentheses followed by any chars. The name of the captured group is specified in '?<name>'
-  const parenthesis = /(?<paren>\(+)(?<term>.+)/;
-  const operators = /O?NEAR(\/[0-9])*|AND|OR|NOT/; // IEEE search operators
-  const ending = /[a-z0-9]+"[)]*/;
-  let phrase = false; // for checking if we're inside a multi-word phrase (a phrase is surrounded by double quotes)
-
-  return queryText.toString().split(' ').map((term) => {
-    if (term.match(operators)) return term; // checks if it's an IEEE operator
-    if (phrase) { // check if we're in the middle of a multi-word phrase
-      if (term.match(ending)) phrase = false; // record the end of a phrase. Nested phrases aren't checked for
-      return term;
-    }
-    // Check for the start of a multi-word phrase, single double-quoted words are managed like any other term
-    if (term.startsWith('"') && !term.endsWith('"')) phrase = true;
-
-    // Test for matching search groups (terms starting with parentheses)
-    // If test returns null, the default group with and empty 'paren' will be used
-    const { groups } = term.match(parenthesis) || { groups: { paren: '', term } };
-    return `${groups.paren}${field}:${groups.term}`;
-  }).join(' ');
+  const operators = /( O?NEAR[/0-9]* | AND | OR | NOT |[()]+)/g; // IEEE search operators and parenthesis
+  return queryText.toString().split(operators).map((term) => {
+    if (term.match(operators) || term === '') return term; // checks if it's an IEEE operator, parenthesis or empty
+    return `${field}:${term}`;
+  }).join('');
 }
 
 module.exports = {

--- a/test/dataFields.test.js
+++ b/test/dataFields.test.js
@@ -17,6 +17,7 @@ test('addDataField with field and parentheses', () => {
 });
 
 test('addDataField with a multi-word phase', () => {
-  const query = 'optics NEAR/15 "nano network gigabyte"';
-  expect(addDataField(query, 'F')).toBe('F:optics NEAR/15 F:"nano network gigabyte"');
+  const query = 'encod* AND ("real time" OR (real ONEAR/2 time)) AND "rate" AND (different NEAR/5 quality)';
+  expect(addDataField(query, 'F'))
+    .toBe('F:encod* AND (F:"real time" OR (F:real ONEAR/2 F:time)) AND F:"rate" AND (F:different NEAR/5 F:quality)');
 });


### PR DESCRIPTION
Previously, we were splitting the query string based on spaces (dumb!). We now split the string based on IEEE operators  and parenthesis. This allows search terms to stay unmodified, including quoted strings and nested parenthesis.