### PR TITLE
fix(utils): better year testing for both arguments and environmental variables

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -34,17 +34,20 @@ function testFileExtension(filename, extension) {
 }
 
 /**
- * Test if year cli option is valid.
+ * Test if years are valid.
  *
- * @param   {number}  year  The number to check if it's valid.
+ * @param   {number[]}  years  The array of years to check with max length of 2.
  *
  * @throws  {TypeError}     Argument has to be an integer.
  * @throws  {RangeError}    Argument has to be between 1900 and current year.
  */
-function testYear(year) {
-  if (!Number.isInteger(year)) throw new TypeError('Year has to be an integer');
-  if (year < 1900) throw new RangeError('Year option has to be after 1900');
-  if (year > new Date().getFullYear()) throw new RangeError('Year option has to be before current year');
+function testYears(years) {
+  if (years.length > 2) throw new TypeError(`Only provide up to two years to specify a range (user ${years})`);
+  for (const year of years) {
+    if (!Number.isInteger(year)) throw new TypeError(`Year has to be an integer (user: ${years})`);
+    if (year < 1900) throw new RangeError(`Year has to be after 1900 (user: ${year})`);
+    if (year > new Date().getFullYear()) throw new RangeError(`Year has to be the current year or earlier (user: ${year})`);
+  }
 }
 
 /**
@@ -75,5 +78,5 @@ module.exports = {
   escapeRegExp,
   getLineStack,
   testFileExtension,
-  testYear,
+  testYears,
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,10 +1,15 @@
 const {
-  changeFileExtension, testFileExtension, testYear, getLineStack,
+  changeFileExtension, testFileExtension, testYears, getLineStack,
 } = require('../src/lib/utils');
 
 const path = 'this/file.ext';
 const out1 = 'this/file.new';
 const out2 = 'this/file.ext.new';
+
+test('getLineStack returns message with line', () => {
+  // the numbers need to change if the next line moves
+  expect(getLineStack()).toBe(`    at ${__filename}:11:10`);
+});
 
 test('changeFileExtension without period', () => {
   expect(changeFileExtension(path, 'new')).toBe(out1);
@@ -22,22 +27,23 @@ test('testFileExtension with same extension', () => {
   expect(testFileExtension(path, '.ext')).toBe(path);
 });
 
-test('testYear not throws for valid year', () => {
-  expect(() => testYear(1990)).not.toThrow();
+test('testYears throws for more than two years', () => {
+  const years = [1990, 1991, 1992];
+  expect(() => testYears(years)).toThrow(`Only provide up to two years to specify a range (user ${years})`);
 });
 
-test('testYear throws if not an integer', () => {
-  expect(() => testYear(15.4)).toThrow('Year has to be an integer');
+test('testYears not throws for valid year', () => {
+  expect(() => testYears([1990])).not.toThrow();
 });
 
-test('testYear throws before 1900', () => {
-  expect(() => testYear(0)).toThrow('Year option has to be after 1900');
+test('testYears throws if not an integer', () => {
+  expect(() => testYears([15.4])).toThrow('Year has to be an integer');
 });
 
-test('testYear throws after current year', () => {
-  expect(() => testYear(1e14)).toThrow('Year option has to be before current year');
+test('testYears throws before 1900', () => {
+  expect(() => testYears([0])).toThrow('Year has to be after 1900 (user: 0)');
 });
 
-test('getLineStack returns message with line', () => {
-  expect(getLineStack()).toBe(`    at ${__filename}:42:10`); // the numbers need to change if this line moves
+test('testYears throws after current year', () => {
+  expect(() => testYears([1e14])).toThrow('Year has to be the current year or earlier (user: 100000000000000)');
 });


### PR DESCRIPTION
yargs has a bug that numbers can be added instead of part of an array. We force yargs to always set yargs arguments as arrays, which changed the logic for testing. The new testing is also used against year environmental variables.