### PR TITLE
feat!: use dotenv to load environmental variables from file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "excel4node": "^1.8.2",
         "fs-extra": "^11.3.0",
         "locate-app": "^2.5.0",
@@ -3903,6 +3904,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotgitignore": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "dotenv": "^16.4.7",
     "excel4node": "^1.8.2",
     "fs-extra": "^11.3.0",
     "locate-app": "^2.5.0",


### PR DESCRIPTION
Load environmental variables from the current working directory, from 'env' or '.env' file.

A single variable ('YEARS'), treated as an array, is used for assigning years. For specifying a range, a colon (:) is used as a separator. Same behavior stays, where a single or two years can be passed.

BREAKING CHANGE: YEAR_START and YEAR_END have been replaces by YEARS. Use YEARS separated by a colon (:), or a single year.