### PR TITLE
feat: assign different output name based on type of OUT env variable

### DIFF
--- a/src/cli-search.js
+++ b/src/cli-search.js
@@ -123,7 +123,8 @@ if (process.env.YEARS) {
 // Sets output name based on env variable 'OUT'
 if (process.env.OUT) {
   if (argv.verbose) console.log(`Using env OUT (${process.env.OUT})`);
-  argv.output = `search${process.env.OUT}`;
+  argv.output = /^[1-9]\d*$/.test(process.env.OUT) ? `search${process.env.OUT}` : process.env.OUT;
+  if (argv.verbose) console.log(`OUT: ${argv.output}`);
 }
 // Set the data field to 'fullTextAndMetadata' based on env variable 'FULL'
 const dataField = process.env.FULL ? 'fullTextAndMetadata' : Object.keys(_.pick(argv, Object.keys(FIELDS)))[0];


### PR DESCRIPTION
If the env variable OUT is a natural number, the output will be the same as it's been (search{num}) Any other type for OUT will use it as the literal name ({OUT})