### PR TITLE
feat: don't add data fields if query already contains them

### DIFF
--- a/src/lib/data-fields.js
+++ b/src/lib/data-fields.js
@@ -28,7 +28,23 @@ function addDataField(queryText, field) {
   }).join('');
 }
 
+/**
+ * Checks if a query string already has IEEE fields.
+ *
+ * @param   {string}  queryText   the search string.
+ * @returns {boolean}             if the search string contains a FIELD or not.
+ */
+function queryContainsField(queryText) {
+  for (const fieldValue of Object.values(FIELDS)) {
+    if (queryText.includes(fieldValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 module.exports = {
   FIELDS,
   addDataField,
+  queryContainsField,
 };

--- a/test/data-fields.test.js
+++ b/test/data-fields.test.js
@@ -1,4 +1,4 @@
-const { addDataField } = require('../src/lib/data-fields');
+const { addDataField, queryContainsField } = require('../src/lib/data-fields');
 
 test('addDataField without field', () => {
   const query = 'optics AND nano';
@@ -20,4 +20,14 @@ test('addDataField with a multi-word phase', () => {
   const query = 'encod* AND ("real time" OR (real ONEAR/2 time)) AND "rate" AND (different NEAR/5 quality)';
   expect(addDataField(query, 'F'))
     .toBe('F:encod* AND (F:"real time" OR (F:real ONEAR/2 F:time)) AND F:"rate" AND (F:different NEAR/5 F:quality)');
+});
+
+test('queryContainsField has a field', () => {
+  const queryText = 'this has a "IEEE Terms":field';
+  expect(queryContainsField(queryText)).toBeTruthy();
+});
+
+test('queryContainsField does not have a field', () => {
+  const queryText = 'this has "not a":field';
+  expect(queryContainsField(queryText)).toBeFalsy();
 });


### PR DESCRIPTION
When using environmental variables, some data fields are automatically added. This is bypassed if the query text already has fields in it.