### PR TITLE
feat!: add option to search all content types or just a subset

### DIFF
--- a/src/cli-search.js
+++ b/src/cli-search.js
@@ -100,6 +100,15 @@ const { argv } = yargs
     describe: 'Show extra info',
     type: 'count',
   })
+  .option('all-content-types', {
+    alias: 'a',
+    describe:
+      'Search across all content types.\n' +
+      'Default content types: Magazines, Conferences, Journals.\n' +
+      'Excluded: Courses, Early Access, Books, Standards',
+    default: false,
+    type: 'boolean',
+  })
   .parserConfiguration({
     'strip-aliased': true,
     'strip-dashed': true,
@@ -161,13 +170,13 @@ if (!queryContainsField(argv._[0])) {
 async function search() {
   let results;
   if (argv.scrap) {
-    results = await ieee.scrap(queryText, argv.year, argv.verbose);
+    results = await ieee.scrap(queryText, argv.year, argv.allContentType, argv.verbose);
   } else {
     const configFile = path.join(configDirectory(), 'config.json');
     checkAPIKey(configFile);
     try {
       const config = fs.readJSONSync(configFile); // Read the API_KEY
-      results = await ieee.api(config.APIKEY, queryText, argv.year, argv.verbose);
+      results = await ieee.api(config.APIKEY, queryText, argv.year, argv.allContentType, argv.verbose);
     } catch (error) {
       console.error('Error reading the APIKEY:', error.message);
       process.exit(1);

--- a/test/ieee-search.test.js
+++ b/test/ieee-search.test.js
@@ -49,7 +49,7 @@ function testIf() {
 
 describe.each(testArray)('Scrapping', ({ label, query, expected }) => {
   test(label, async () => {
-    const results = await scrap(query, rangeYear, false);
+    const results = await scrap(query, rangeYear, true, false);
     const result = results.articles[0];
     delete result.abstract;
     expect(result).toMatchObject(expected);
@@ -58,7 +58,7 @@ describe.each(testArray)('Scrapping', ({ label, query, expected }) => {
 
 describe('Scrapping', () => {
   test('Title without link', async () => {
-    const results = await scrap('optics AND nano AND QELS', [2000, 2000], false);
+    const results = await scrap('optics AND nano AND QELS', [2000, 2000], true, false);
     const result = results.articles[0];
     delete result.abstract;
     expect(result).toMatchObject(untitled[0]);
@@ -67,15 +67,32 @@ describe('Scrapping', () => {
 
 describe('Scrapping', () => {
   test('Results in multiple pages', async () => {
-    await expect(scrap('nack', [2000, 2003], false)).resolves.toMatchObject(expectedJson.multiple);
+    await expect(scrap('nack', [2000, 2003], true, false)).resolves.toMatchObject(expectedJson.multiple);
+  });
+});
+
+describe('Scrapping', () => {
+  test("Don't search all content types", async () => {
+    await expect(scrap(queries.standard, [2000, 2000], false, false)).resolves.toMatchObject({
+      articles: [],
+      total_records: 0,
+    });
   });
 });
 
 describe.each(testArray)('Official API', ({ label, query, expected }) => {
   testIf()(label, async () => {
-    const results = await api(process.env.APIKEY, query, rangeYear, false);
+    const results = await api(process.env.APIKEY, query, rangeYear, true, false);
     const result = results.articles[0];
     delete result.abstract;
     expect(result).toMatchObject(expected);
+  });
+});
+
+describe('Official API', () => {
+  testIf()("Don't search all content types", async () => {
+    await expect(api(process.env.APIKEY, queries.standard, [2000, 2000], false, false)).resolves.toMatchObject({
+      total_records: 0,
+    });
   });
 });


### PR DESCRIPTION
We now can choose what content we search for both scrap and API. Sci-hub doesn't have access to books, standards, and courses. In addition, this types are less relevant than the default ones.

BREAKING CHANGE: The default only searches for Journals, Magazines, and Conferences. Use the --all-content-types option to search for all types.