### PR TITLE
feat!: prioritize years argument over environmental variable

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   js.configs.recommended,
   nodePlugin.configs['flat/recommended-script'],
   importPlugin.flatConfigs.recommended,
-  eslintConfigPrettier,
+  { ignores: ['build/'] },
   {
     rules: {
       'import/no-unresolved': ['error', { ignore: ['^fs-extra/esm$'] }],
@@ -39,4 +39,5 @@ export default [
       'n/no-unpublished-import': 'off',
     },
   },
+  eslintConfigPrettier,
 ];

--- a/src/cli-search.mjs
+++ b/src/cli-search.mjs
@@ -139,8 +139,8 @@ const { argv } = yargsInstance
   );
 
 /* Assigns environmental variables if present */
-// Sets year from env variable 'YEARS'
-if (process.env.YEARS) {
+// Sets year from env variable 'YEARS' if an argument wasn't explicitly pass
+if (process.env.YEARS && !argv.year) {
   if (argv.verbose) console.log(`Using env YEARS (${process.env.YEARS})`);
   const years = process.env.YEARS.split(':').map((year) => Number.parseInt(year, 10)); // creates an array of years
   try {


### PR DESCRIPTION
This change helps when running one-time commands with different years than the project specified. For example, when searching for cited art.

BREAKING CHANGE: When both argument and environmental variables are present, prioritize the argument