### PR TITLE
feat: add option to show only scrap link

### DIFF
--- a/src/cli-search.mjs
+++ b/src/cli-search.mjs
@@ -8,7 +8,7 @@ import { checkAPIKey } from './lib/api-key.mjs';
 import { configDirectory } from './lib/config-directory.mjs';
 import { testYears, checkQueryText, testFileExtension } from './lib/helpers.mjs';
 import { FIELDS, addDataField, queryContainsField } from './lib/data-fields.mjs';
-import { scrap, api } from './lib/ieee-api.mjs';
+import { scrap, api, scrapLink } from './lib/ieee-api.mjs';
 import { fromResults as json2xls } from './lib/json2xls.mjs';
 
 const yargsInstance = yargs(process.argv.slice(2));
@@ -113,6 +113,12 @@ const { argv } = yargsInstance
     default: false,
     type: 'boolean',
   })
+  .option('link-only', {
+    alias: 'l',
+    describe: 'Show the IEEE search link only, like verbose\n' + 'This is useful to check the list of publishers',
+    default: false,
+    type: 'boolean',
+  })
   .parserConfiguration({
     'strip-aliased': true,
     'strip-dashed': true,
@@ -205,4 +211,9 @@ async function search() {
     }
   }
 }
-search();
+if (argv.linkOnly) {
+  const query = scrapLink(queryText, argv.year, argv.allContentTypes);
+  console.log('Encoded Query: %s\n', query);
+} else {
+  search();
+}

--- a/src/lib/ieee-api.mjs
+++ b/src/lib/ieee-api.mjs
@@ -202,4 +202,15 @@ async function api(apiKey, queryText, rangeYear, allContentTypes, verbose) {
   return response.data;
 }
 
-export { scrap, api };
+function scrapLink(queryText, rangeYear, allContentTypes) {
+  const ieeeSearchUrl = 'https://ieeexplore.ieee.org/search/searchresult.jsp';
+  let query =
+    `?queryText=(${encodeURI(queryText).replaceAll('?', '%3F').replaceAll('/', '%2F')})` +
+    `&ranges=${rangeYear[0]}_${rangeYear[1]}_Year`;
+  if (!allContentTypes) {
+    query += '&refinements=ContentType:Conferences&refinements=ContentType:Journals&refinements=ContentType:Magazines';
+  }
+  return ieeeSearchUrl + query;
+}
+
+export { scrap, api, scrapLink };


### PR DESCRIPTION
This option helps to get a list of publishers from the result directly from the website. Perhaps there should be a way to get publishers from the API as a csv.